### PR TITLE
Make ratings more user-friendly

### DIFF
--- a/kubernetes/bookinfo-gql.yaml
+++ b/kubernetes/bookinfo-gql.yaml
@@ -6,80 +6,87 @@ metadata:
 spec:
   enableIntrospection: true
   resolutions:
-  - matcher:
-      fieldMatcher:
-        field: productsForHome
-        type: Query
-    restResolver:
-      request:
-        headers:
-          :method: GET
-          :path: /api/v1/products
-      upstreamRef:
-        name: default-productpage-9080
-        namespace: gloo-system
-  - matcher:
-      fieldMatcher:
-        field: detail
-        type: Product
-    restResolver:
-      request:
-        headers:
-          :method: GET
-          :path: "/details/{$parent.id}"
-      upstreamRef:
-        name:  default-details-9080
-        namespace: gloo-system
-  - matcher:
-      fieldMatcher:
-        field: review
-        type: Product
-    restResolver:
-      request:
-        headers:
-          :method: GET
-          :path: "/reviews/{$parent.id}"
-      response:
-        resultRoot: "reviews"
-      upstreamRef:
-        name:  default-reviews-9080
-        namespace: gloo-system
-  - matcher:
-      fieldMatcher:
-        field: ratings
-        type: Product
-    restResolver:
-      request:
-        headers:
-          :method: GET
-          :path: "/ratings/{$parent.id}"
-      response:
-        resultRoot: "ratings[*]"
-        setters:
-          reviewer: "[*][0]"
-          numStars: "[*][1]"
-      upstreamRef:
-        name:  default-ratings-9080
-        namespace: gloo-system
+    Query|productsForHome:
+      restResolver:
+        request:
+          headers:
+            :method: GET
+            :path: /api/v1/products
+        upstreamRef:
+          name: default-productpage-9080
+          namespace: gloo-system
+    author:
+      restResolver:
+        request:
+          headers:
+            :method: GET
+            :path: /details/{$parent.id}
+        response:
+          resultRoot: "author"
+        upstreamRef:
+          name: default-details-9080
+          namespace: gloo-system
+    pages:
+      restResolver:
+        request:
+          headers:
+            :method: GET
+            :path: /details/{$parent.id}
+        response:
+          resultRoot: "pages"
+        upstreamRef:
+          name: default-details-9080
+          namespace: gloo-system
+    year:
+      restResolver:
+        request:
+          headers:
+            :method: GET
+            :path: /details/{$parent.id}
+        response:
+          resultRoot: "year"
+        upstreamRef:
+          name: default-details-9080
+          namespace: gloo-system
+    reviews:
+      restResolver:
+        request:
+          headers:
+            :method: GET
+            :path: /reviews/{$parent.id}
+        response:
+          resultRoot: "reviews"
+        upstreamRef:
+          name: default-reviews-9080
+          namespace: gloo-system
+    ratings:
+      restResolver:
+        request:
+          headers:
+            :method: GET
+            :path: /ratings/{$parent.id}
+        response:
+          resultRoot: "ratings[*]"
+          setters:
+            reviewer: "[*][0]"
+            numStars: "[*][1]"
+        upstreamRef:
+          name: default-ratings-9080
+          namespace: gloo-system
   schema: |
     type Query {
-      productsForHome: [Product]
+      productsForHome: [Product] @resolve(name: "Query|productsForHome")
     }
 
     type Product {
       id: String
       title: String
       descriptionHtml: String
-      detail : ProductDetail
-      review: [Review]
-      ratings: [Rating]
-    }
-
-    type ProductDetail {
-      id: String
-      author: String
-      pages: Int
-      year: Int
+      author: String @resolve(name: "author")
+      pages: Int @resolve(name: "pages")
+      year: Int @resolve(name: "year")
+      reviews : [Review] @resolve(name: "reviews")
+      ratings : [Rating] @resolve(name: "ratings")
     }
 
     type Review {
@@ -88,6 +95,6 @@ spec:
     }
 
     type Rating {
-      reviewer: String
-      numStars: Int
+      reviewer : String
+      numStars : Int
     }

--- a/kubernetes/bookinfo-gql.yaml
+++ b/kubernetes/bookinfo-gql.yaml
@@ -6,84 +6,80 @@ metadata:
 spec:
   enableIntrospection: true
   resolutions:
-    Query|productsForHome:
-      restResolver:
-        request:
-          headers:
-            :method: GET
-            :path: /api/v1/products
-        upstreamRef:
-          name: default-productpage-9080
-          namespace: gloo-system
-    author:
-      restResolver:
-        request:
-          headers:
-            :method: GET
-            :path: /details/{$parent.id}
-        response:
-          resultRoot: "author"
-        upstreamRef:
-          name: default-details-9080
-          namespace: gloo-system
-    pages:
-      restResolver:
-        request:
-          headers:
-            :method: GET
-            :path: /details/{$parent.id}
-        response:
-          resultRoot: "pages"
-        upstreamRef:
-          name: default-details-9080
-          namespace: gloo-system
-    year:
-      restResolver:
-        request:
-          headers:
-            :method: GET
-            :path: /details/{$parent.id}
-        response:
-          resultRoot: "year"
-        upstreamRef:
-          name: default-details-9080
-          namespace: gloo-system
-    reviews:
-      restResolver:
-        request:
-          headers:
-            :method: GET
-            :path: /reviews/{$parent.id}
-        response:
-          resultRoot: "reviews"
-        upstreamRef:
-          name: default-reviews-9080
-          namespace: gloo-system
-    ratings:
-      restResolver:
-        request:
-          headers:
-            :method: GET
-            :path: /ratings/{$parent.id}
-        response:
-          resultRoot: "ratings"
-        upstreamRef:
-          name: default-ratings-9080
-          namespace: gloo-system
+  - matcher:
+      fieldMatcher:
+        field: productsForHome
+        type: Query
+    restResolver:
+      request:
+        headers:
+          :method: GET
+          :path: /api/v1/products
+      upstreamRef:
+        name: default-productpage-9080
+        namespace: gloo-system
+  - matcher:
+      fieldMatcher:
+        field: detail
+        type: Product
+    restResolver:
+      request:
+        headers:
+          :method: GET
+          :path: "/details/{$parent.id}"
+      upstreamRef:
+        name:  default-details-9080
+        namespace: gloo-system
+  - matcher:
+      fieldMatcher:
+        field: review
+        type: Product
+    restResolver:
+      request:
+        headers:
+          :method: GET
+          :path: "/reviews/{$parent.id}"
+      response:
+        resultRoot: "reviews"
+      upstreamRef:
+        name:  default-reviews-9080
+        namespace: gloo-system
+  - matcher:
+      fieldMatcher:
+        field: ratings
+        type: Product
+    restResolver:
+      request:
+        headers:
+          :method: GET
+          :path: "/ratings/{$parent.id}"
+      response:
+        resultRoot: "ratings[*]"
+        setters:
+          reviewer: "[*][0]"
+          numStars: "[*][1]"
+      upstreamRef:
+        name:  default-ratings-9080
+        namespace: gloo-system
   schema: |
     type Query {
-      productsForHome: [Product] @resolve(name: "Query|productsForHome")
+      productsForHome: [Product]
     }
 
     type Product {
       id: String
       title: String
       descriptionHtml: String
-      author: String @resolve(name: "author")
-      pages: Int @resolve(name: "pages")
-      year: Int @resolve(name: "year")
-      reviews : [Review] @resolve(name: "reviews")
-      ratings : Rating @resolve(name: "ratings")
+      detail : ProductDetail
+      review: [Review]
+      ratings: [Rating]
+    }
+
+    type ProductDetail {
+      id: String
+      author: String
+      pages: Int
+      year: Int
     }
 
     type Review {
@@ -92,6 +88,6 @@ spec:
     }
 
     type Rating {
-      Reviewer1 : String
-      Reviewer2 : String
+      reviewer: String
+      numStars: Int
     }


### PR DESCRIPTION
The ratings API serves back ratings in the form: 
```json
{ "ratings": {
  "Reviewer1": 2,
  "Reviewer2": 5,
}}
```
-- basically a map of reviewer name to rating. This is not very graphql-esque as graphql requires strongly typed objects and we would need a type like 
```gql
type Rating {
  Reviewer1: Int
  Reviewer2: Int
}
```
which doesn't scale well. Let's instead use result setters to transform the data into a more usable form: an array of `[Rating]` where rating is
```gql
type Rating {
   reviewer: String
  numStars: Int
}
```

In order to marshal this into a more friendly graphql format, where there could be `n` number of reviewers, we can use the transformations

```yaml
        resultRoot: "ratings[*]"
          setters:
            reviewer: "[*][0]"
            numStars: "[*][1]"
```

where essentially the `resultRoot` is "spreading" out the `ratings` object with the spread operator `[*]`. So this turns the upstream data into an array of key-value pairs`[["Reviewer1", 2], ["Reviewer2", 5]]`. Then we use the `setters` to extract the information **per-object**. 
For example, with the `reviewer` setter, we use the spread operator first `[*]` to indicate that we want the following operations to be spread over all the elements of the array we are dealing with. Then we use the index operator `[0]` to extract the first element of each of the key value pairs.